### PR TITLE
Fixing links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ This directory consists of examples and templates for you to set up your infrast
 
 ### NIMS-INFERENCE
 
-This project aims to reduce the effort required to set up optimized inference workloads on AWS, with the help of NVIDIA NIMs. NIMs provides users with an efficient optimization framework that is very quick and easy to set up. The example shown demonstrates running the Llama3-8B model on P5 instances and scaling with Amazon Elastic Kubernetes Service (EKS). See [nims-inference](https://github.com/aws-samples/awsome-inference/blob/main/nims-inference/README.md) for more information.
+This project aims to reduce the effort required to set up optimized inference workloads on AWS, with the help of NVIDIA NIMs. NIMs provides users with an efficient optimization framework that is very quick and easy to set up. The example shown demonstrates running the Llama3-8B model on P5 instances and scaling with Amazon Elastic Kubernetes Service (EKS). See [nims-inference](https://github.com/aws-samples/awsome-inference/blob/main/2.projects/nims-inference/README.md) for more information.
 
 ### TRTLLM-INFERENCE
 
 This project aims at optimizing inference on GPU based AWS Accelerated Computing instances by demonstrating an example of running the Llama3-8B model on P5 instances and optimizing inference using NVIDIA's TensorRT-LLM. Scaling is demonstrated using Amazon Elastic Kubernetes Service (EKS).
-See [trtllm-inference](https://github.com/aws-samples/awsome-inference/blob/main/trtllm-inference/README.md) for more information.
+See [trtllm-inference](https://github.com/aws-samples/awsome-inference/blob/main/2.projects/trtllm-inference/README.md) for more information.
 
 
 ## Security


### PR DESCRIPTION
Looks like the links didn't get updated after a directory reorganization.  Just fixed the paths.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
